### PR TITLE
docs: document safe Helm CRD upgrades

### DIFF
--- a/charts/lws/README.md
+++ b/charts/lws/README.md
@@ -8,6 +8,7 @@
     - [Installing the chart](#installing-the-chart)
         - [Install chart using Helm v3.0+](#install-chart-using-helm-v30)
         - [Verify that controller pods are running properly.](#verify-that-controller-pods-are-running-properly)
+        - [Upgrading the chart](#upgrading-the-chart)
     - [Configuration](#configuration)
 <!-- /toc -->
 
@@ -46,6 +47,17 @@ NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
 lws-system-controller-manager   1/1     1            1           14s
 ```
 
+##### Upgrading the chart
+
+Helm installs CRDs during `helm install`, but does not automatically upgrade CRDs
+from the chart `crds/` directory during `helm upgrade`. See the
+[installation guide](https://lws.sigs.k8s.io/docs/installation/#upgrade-by-helm)
+for the recommended upgrade flow.
+
+If you are upgrading from LWS `v0.7.0` or earlier to `v0.8.0` or later, see the
+[troubleshooting guide](https://lws.sigs.k8s.io/docs/troubleshooting/#4-leaderworkerset-crd-missing-after-helm-upgrade)
+before running `helm upgrade`.
+
 ##### Cert Manager
 
 LWS has support for third-party certificates.
@@ -70,8 +82,8 @@ editor/viewer/admin ClusterRoles and validating webhook, set
 
 Helm installs CRDs during `helm install`, but does not install newly added CRDs
 during `helm upgrade`. Before upgrading an existing LWS Helm release to a chart
-version that introduces DisaggregatedSet, apply the new CRD from the repository
-root:
+version that introduces DisaggregatedSet, follow the safe Helm upgrade flow
+above or apply the new CRD from the repository root:
 
 ```bash
 kubectl apply --server-side \

--- a/hack/prepare-helm-legacy-crd-upgrade.sh
+++ b/hack/prepare-helm-legacy-crd-upgrade.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly DEFAULT_RELEASE_NAME="lws"
+readonly DEFAULT_NAMESPACE="lws-system"
+readonly DEFAULT_CHART="oci://registry.k8s.io/lws/charts/lws"
+readonly LEADERWORKERSET_CRD="leaderworkersets.leaderworkerset.x-k8s.io"
+readonly WEBHOOK_SERVICE="lws-webhook-service"
+
+release_name="${DEFAULT_RELEASE_NAME}"
+namespace="${DEFAULT_NAMESPACE}"
+chart="${DEFAULT_CHART}"
+chart_version=""
+backup_dir=""
+
+function usage {
+  cat <<EOF
+Prepare an existing LWS Helm release for a historical CRD layout upgrade.
+
+This script does not run helm upgrade. It backs up the current release state,
+protects the historical LeaderWorkerSet CRD from Helm deletion, applies the
+target chart CRDs, patches the LeaderWorkerSet conversion webhook namespace, and
+prints the helm upgrade command to run next.
+
+Usage:
+  hack/prepare-helm-legacy-crd-upgrade.sh --chart-version <version> [flags]
+
+Flags:
+  --chart-version <version>   Target LWS Helm chart version, for example 0.8.0. Required.
+  --release-name <name>       Helm release name. Default: ${DEFAULT_RELEASE_NAME}
+  --namespace <namespace>     Helm release namespace. Default: ${DEFAULT_NAMESPACE}
+  --chart <chart>             Helm chart reference. Default: ${DEFAULT_CHART}
+  --backup-dir <path>         Directory for backup files. Default: lws-helm-upgrade-backup-<timestamp>
+  -h, --help                  Show this help message.
+EOF
+}
+
+function log {
+  echo "==> $*"
+}
+
+function warn {
+  echo "WARNING: $*" >&2
+}
+
+function die {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+function require_command {
+  local command_name="$1"
+  command -v "${command_name}" >/dev/null 2>&1 || die "${command_name} is required"
+}
+
+function parse_args {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --chart-version)
+        [[ $# -ge 2 ]] || die "--chart-version requires a value"
+        chart_version="$2"
+        shift 2
+        ;;
+      --release-name)
+        [[ $# -ge 2 ]] || die "--release-name requires a value"
+        release_name="$2"
+        shift 2
+        ;;
+      --namespace)
+        [[ $# -ge 2 ]] || die "--namespace requires a value"
+        namespace="$2"
+        shift 2
+        ;;
+      --chart)
+        [[ $# -ge 2 ]] || die "--chart requires a value"
+        chart="$2"
+        shift 2
+        ;;
+      --backup-dir)
+        [[ $# -ge 2 ]] || die "--backup-dir requires a value"
+        backup_dir="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "${chart_version}" ]] || die "--chart-version is required"
+  if [[ -z "${backup_dir}" ]]; then
+    backup_dir="lws-helm-upgrade-backup-$(date +%Y%m%d%H%M%S)"
+  fi
+}
+
+function backup_release_state {
+  log "Writing backup files to ${backup_dir}"
+  mkdir -p "${backup_dir}"
+
+  helm get values "${release_name}" --namespace "${namespace}" --all \
+    > "${backup_dir}/helm-values.yaml"
+  helm get manifest "${release_name}" --namespace "${namespace}" \
+    > "${backup_dir}/helm-manifest.yaml"
+
+  if kubectl get crd "${LEADERWORKERSET_CRD}" >/dev/null 2>&1; then
+    kubectl get crd "${LEADERWORKERSET_CRD}" -o yaml \
+      > "${backup_dir}/leaderworkerset-crd.yaml"
+    kubectl get "${LEADERWORKERSET_CRD}" --all-namespaces -o yaml \
+      > "${backup_dir}/leaderworkersets.yaml"
+  else
+    warn "CRD ${LEADERWORKERSET_CRD} was not found; LeaderWorkerSet objects cannot be backed up"
+  fi
+}
+
+function annotate_crd_keep {
+  local crd_name="$1"
+  if kubectl get crd "${crd_name}" >/dev/null 2>&1; then
+    kubectl annotate crd "${crd_name}" "helm.sh/resource-policy=keep" --overwrite
+  else
+    warn "CRD ${crd_name} was not found; skipping keep annotation"
+  fi
+}
+
+function apply_target_crds {
+  local crds_file
+  local normalized_crds_file
+  crds_file="$(mktemp)"
+  normalized_crds_file="$(mktemp)"
+
+  log "Fetching CRDs from ${chart} version ${chart_version}"
+  if ! helm show crds "${chart}" --version "${chart_version}" > "${crds_file}"; then
+    rm -f "${crds_file}"
+    rm -f "${normalized_crds_file}"
+    die "failed to fetch CRDs from ${chart} version ${chart_version}"
+  fi
+  if [[ ! -s "${crds_file}" ]]; then
+    rm -f "${crds_file}"
+    rm -f "${normalized_crds_file}"
+    die "no CRDs were found in ${chart} version ${chart_version}"
+  fi
+
+  awk '
+    $0 == "apiVersion: apiextensions.k8s.io/v1" {
+      if (seen++) {
+        print "---"
+      }
+    }
+    { print }
+  ' "${crds_file}" > "${normalized_crds_file}"
+
+  log "Applying target chart CRDs"
+  kubectl apply --server-side --force-conflicts -f "${normalized_crds_file}"
+  rm -f "${crds_file}"
+  rm -f "${normalized_crds_file}"
+}
+
+function patch_conversion_webhook {
+  if ! kubectl get crd "${LEADERWORKERSET_CRD}" >/dev/null 2>&1; then
+    warn "CRD ${LEADERWORKERSET_CRD} was not found; skipping conversion webhook patch"
+    return
+  fi
+
+  log "Patching LeaderWorkerSet conversion webhook namespace"
+  local conversion_patch
+  conversion_patch=$(cat <<EOF
+{"spec":{"conversion":{"strategy":"Webhook","webhook":{"conversionReviewVersions":["v1"],"clientConfig":{"service":{"namespace":"${namespace}","name":"${WEBHOOK_SERVICE}","path":"/convert"}}}}}}
+EOF
+)
+  kubectl patch crd "${LEADERWORKERSET_CRD}" --type=merge -p "${conversion_patch}"
+}
+
+function print_next_steps {
+  cat <<EOF
+
+The LWS Helm release is prepared for upgrade.
+
+Run helm upgrade with the same --values and --set options used by the existing
+release, for example:
+
+helm upgrade ${release_name} ${chart} \\
+  --version ${chart_version} \\
+  --namespace ${namespace} \\
+  --wait --timeout 300s
+
+EOF
+
+  echo "Backup files were written to: ${backup_dir}"
+}
+
+parse_args "$@"
+
+require_command helm
+require_command kubectl
+
+log "Checking Helm release ${release_name} in namespace ${namespace}"
+helm status "${release_name}" --namespace "${namespace}" >/dev/null
+
+backup_release_state
+
+log "Protecting historical LeaderWorkerSet CRD before applying target CRDs"
+annotate_crd_keep "${LEADERWORKERSET_CRD}"
+
+apply_target_crds
+patch_conversion_webhook
+
+log "Re-applying keep annotation to the historical LeaderWorkerSet CRD"
+annotate_crd_keep "${LEADERWORKERSET_CRD}"
+
+print_next_steps

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -9,6 +9,9 @@ description: >
 <!-- toc -->
 - [Before you begin](#before-you-begin)
 - [Install a released version](#install-a-released-version)
+  - [Install by kubectl](#install-by-kubectl)
+  - [Install by Helm](#install-by-helm)
+  - [Upgrade by Helm](#upgrade-by-helm)
   - [Uninstall](#uninstall)
 - [Install the latest development version](#install-the-latest-development-version)
   - [Uninstall](#uninstall-1)
@@ -72,6 +75,30 @@ helm install lws https://github.com/kubernetes-sigs/lws/releases/download/$VERSI
   --create-namespace \
   --wait --timeout 300s
 ```
+
+### Upgrade by Helm
+
+Apply CRDs from the target chart before running `helm upgrade`:
+
+```shell
+CHART=oci://registry.k8s.io/lws/charts/lws
+CHART_VERSION=0.9.0
+
+# helm show crds can concatenate CRD YAML without document separators.
+helm show crds "$CHART" --version "$CHART_VERSION" \
+  | awk '$0 == "apiVersion: apiextensions.k8s.io/v1" { if (seen++) print "---" } { print }' \
+  | kubectl apply --server-side --force-conflicts -f -
+
+helm upgrade lws "$CHART" \
+  --version "$CHART_VERSION" \
+  --namespace lws-system \
+  --wait --timeout 300s
+```
+
+Include any `--values` or `--set` options used by the existing release.
+
+If you are upgrading from LWS `v0.7.0` or earlier to `v0.8.0` or later, see
+[troubleshooting](/docs/troubleshooting/#4-leaderworkerset-crd-missing-after-helm-upgrade).
 
 ### Uninstall
 

--- a/site/content/en/docs/troubleshooting/_index.md
+++ b/site/content/en/docs/troubleshooting/_index.md
@@ -64,3 +64,36 @@ This issue occurs because StatefulSet names exceeding 57 characters prevent pods
 ### Solution
 
 The name limit for LWS objects is calculated as `(51 - int(replicas / 10))`. This is because the worker StatefulSet name grows by one character for replicas above 9, another character for replicas above 99, and so on. Ensure that the LWS object name adheres to this limit to avoid issues.
+
+---
+
+## 4. LeaderWorkerSet CRD Missing After Helm Upgrade
+
+When upgrading an LWS Helm release from `v0.7.0` or earlier to `v0.8.0` or
+later, the `leaderworkersets.leaderworkerset.x-k8s.io` CRD might be deleted.
+If this happens, existing LeaderWorkerSet objects are also removed by Kubernetes
+garbage collection.
+
+### Cause
+
+LWS charts before `v0.8.0` stored the LeaderWorkerSet CRD in the regular Helm
+templates. Starting with `v0.8.0`, the CRDs are stored in the chart `crds/`
+directory. During an upgrade across this layout change, Helm can see the CRD in
+the old release manifest but not in the new rendered templates, then treat it as
+a deleted resource.
+
+### Solution
+
+Before upgrading a Helm installation from `v0.7.0` or earlier to `v0.8.0` or
+later, run the helper script before `helm upgrade`:
+
+```shell
+CHART_VERSION=0.9.0
+hack/prepare-helm-legacy-crd-upgrade.sh --chart-version "$CHART_VERSION"
+```
+
+Then run `helm upgrade` with the same `--values` and `--set` options used by the
+existing release.
+
+If the CRD was already deleted, restore the LeaderWorkerSet resources from your
+cluster backup, then run the helper script before the next upgrade attempt.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it

This PR documents safe Helm upgrade guidance for LWS installations that cross the historical CRD layout change.

LWS charts before `v0.8.0` stored the LeaderWorkerSet CRD in regular Helm templates. Starting with `v0.8.0`, CRDs are stored in the chart `crds/` directory. For releases installed with `v0.7.0` or earlier, a direct Helm upgrade to `v0.8.0` or later can cause Helm to delete the historical LeaderWorkerSet CRD and existing LeaderWorkerSet objects.

This PR adds:

- Helm upgrade guidance that applies target chart CRDs before `helm upgrade`.
- Troubleshooting guidance for the historical `v0.7.0` or earlier to `v0.8.0` or later upgrade path.
- A short chart README note linking users to the installation and troubleshooting docs.
- `hack/prepare-helm-legacy-crd-upgrade.sh`, a helper script that backs up the current release state, applies target chart CRDs, patches the LeaderWorkerSet conversion webhook namespace, annotates the historical LeaderWorkerSet CRD with `helm.sh/resource-policy=keep`, and prints the final `helm upgrade` command.

The helper script does not run `helm upgrade`; users still run the final upgrade with their existing `--values` and `--set` options.

#### Which issue(s) this PR fixes

Refs https://github.com/kubernetes-sigs/lws/issues/880

#### Special notes for your reviewer

This is a documentation-first mitigation for the historical upgrade path. It does not add a Helm hook, move CRDs, or introduce a new LWS image.

Validation performed:

- `bash -n hack/prepare-helm-legacy-crd-upgrade.sh`
- `git diff --check`
- kind validation from chart `0.7.0` to chart `0.9.0` with multiple LeaderWorkerSet objects across namespaces:
  - the helper script preserved all LeaderWorkerSet objects
  - object UIDs and specs were unchanged after upgrade
  - the LeaderWorkerSet CRD kept `helm.sh/resource-policy=keep`
  - the DisaggregatedSet CRD was applied
- negative control without the helper reproduced the missing LeaderWorkerSet CRD after direct Helm upgrade

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
